### PR TITLE
feature/#8 [샵 등록 신청 API 구현]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("io.micrometer:micrometer-tracing-bridge-brave")
 	implementation("io.zipkin.reporter2:zipkin-reporter-brave")
 	//implementation("org.flywaydb:flyway-core")

--- a/src/main/java/com/luckytree/shop_service/adapter/in/CreateShopController.java
+++ b/src/main/java/com/luckytree/shop_service/adapter/in/CreateShopController.java
@@ -1,0 +1,25 @@
+package com.luckytree.shop_service.adapter.in;
+
+import com.luckytree.shop_service.application.port.in.CreateShopUseCase;
+import com.luckytree.shop_service.application.port.in.RequestShopRegistration;
+import com.luckytree.shop_service.common.dto.ResultResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/shop/create")
+@RequiredArgsConstructor
+public class CreateShopController {
+
+    private final CreateShopUseCase createShopUseCase;
+
+    @PostMapping("/request")
+    public ResultResponse requestShopRegistration(@Valid RequestShopRegistration requestShopRegistration) {
+        createShopUseCase.requestShopRegistration(requestShopRegistration);
+        return new ResultResponse<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/luckytree/shop_service/adapter/out/BaseTimeEntity.java
+++ b/src/main/java/com/luckytree/shop_service/adapter/out/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.luckytree.shop_service.domain;
+package com.luckytree.shop_service.adapter.out;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;

--- a/src/main/java/com/luckytree/shop_service/adapter/out/CreateShopPersistenceAdapter.java
+++ b/src/main/java/com/luckytree/shop_service/adapter/out/CreateShopPersistenceAdapter.java
@@ -1,0 +1,22 @@
+package com.luckytree.shop_service.adapter.out;
+
+import com.luckytree.shop_service.application.port.out.CreateShopPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+public class CreateShopPersistenceAdapter implements CreateShopPort {
+
+    private final ShopDetailRepository shopDetailRepository;
+    private final ShopListRepository shopListRepository;
+
+    @Override
+    public Long saveShopDetail(ShopDetailEntity shopDetailEntity) {
+        return shopDetailRepository.save(shopDetailEntity).getId();
+    }
+
+    @Override
+    public void saveShopList(ShopListEntity shopListEntity) {
+        shopListRepository.save(shopListEntity);
+    }
+}

--- a/src/main/java/com/luckytree/shop_service/adapter/out/ShopDetailEntity.java
+++ b/src/main/java/com/luckytree/shop_service/adapter/out/ShopDetailEntity.java
@@ -1,0 +1,48 @@
+package com.luckytree.shop_service.adapter.out;
+
+import com.luckytree.shop_service.domain.Hashtag;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+
+@Table(name = "shop_detail")
+@Getter
+@Builder
+@Entity
+public class ShopDetailEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 50, nullable = false)
+    private String name;
+
+    @Column(length = 50)
+    private String category;
+
+    @Column(length = 50, nullable = false)
+    private String address;
+
+    @Column(length = 150)
+    private String photo;
+
+    @Column(length = 50)
+    private String contact;
+
+    @Column(length = 50)
+    private String homepage;
+
+    @Column(length = 50)
+    private String flagshipProduct;
+
+    @Column(length = 50)
+    private Hashtag hashtag;
+
+    @Column(length = 50, nullable = false)
+    private String operatingTime;
+
+    @Column(length = 50)
+    private String sns;
+
+}

--- a/src/main/java/com/luckytree/shop_service/adapter/out/ShopDetailRepository.java
+++ b/src/main/java/com/luckytree/shop_service/adapter/out/ShopDetailRepository.java
@@ -1,4 +1,9 @@
 package com.luckytree.shop_service.adapter.out;
 
-public interface ShopDetailRepository {
+import com.luckytree.shop_service.domain.ShopDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ShopDetailRepository extends JpaRepository<ShopDetailEntity, Long> {
 }

--- a/src/main/java/com/luckytree/shop_service/adapter/out/ShopListEntity.java
+++ b/src/main/java/com/luckytree/shop_service/adapter/out/ShopListEntity.java
@@ -1,0 +1,35 @@
+package com.luckytree.shop_service.adapter.out;
+
+import com.luckytree.shop_service.domain.Hashtag;
+import com.luckytree.shop_service.domain.ShopStatus;
+import jakarta.persistence.*;
+import lombok.Builder;
+
+@Table(name = "shop_list")
+@Builder
+@Entity
+public class ShopListEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 20, nullable = false)
+    private Long shopDetailId;
+
+    @Column(length = 50, nullable = false)
+    private String name;
+
+    @Column(length = 10, nullable = false)
+    private ShopStatus status;
+
+    private Double mapX;
+
+    private Double mapY;
+
+    @Column(length = 50)
+    private String category;
+
+    @Column(length = 50)
+    private Hashtag hashtag;
+}

--- a/src/main/java/com/luckytree/shop_service/adapter/out/ShopListRepository.java
+++ b/src/main/java/com/luckytree/shop_service/adapter/out/ShopListRepository.java
@@ -1,4 +1,9 @@
 package com.luckytree.shop_service.adapter.out;
 
-public interface ShopListRepository {
+import com.luckytree.shop_service.domain.ShopList;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ShopListRepository extends JpaRepository<ShopListEntity, Long> {
 }

--- a/src/main/java/com/luckytree/shop_service/application/port/in/CreateShopUseCase.java
+++ b/src/main/java/com/luckytree/shop_service/application/port/in/CreateShopUseCase.java
@@ -1,0 +1,7 @@
+package com.luckytree.shop_service.application.port.in;
+
+import com.luckytree.shop_service.common.dto.ResultResponse;
+
+public interface CreateShopUseCase {
+    void requestShopRegistration(RequestShopRegistration requestShopRegistration);
+}

--- a/src/main/java/com/luckytree/shop_service/application/port/in/RequestShopRegistration.java
+++ b/src/main/java/com/luckytree/shop_service/application/port/in/RequestShopRegistration.java
@@ -1,0 +1,50 @@
+package com.luckytree.shop_service.application.port.in;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RequestShopRegistration {
+
+    @NotBlank
+    @Size(max = 50)
+    private String shopName;
+
+    @Size(max = 50)
+    private String category;
+
+    @NotBlank
+    @Size(max = 50)
+    private String address;
+
+    @Size(max = 150)
+    private String photo;
+
+    @Size(max = 50)
+    private String contact;
+
+    @Size(max = 50)
+    private String homepage;
+
+    @Size(max = 50)
+    private String flagshipProduct;
+
+    @NotBlank
+    @Size(max = 50)
+    private String operatingTime;
+
+    @Size(max = 50)
+    private String sns;
+
+    @NotBlank
+    private double mapX;
+
+    @NotBlank
+    private double mapY;
+}

--- a/src/main/java/com/luckytree/shop_service/application/port/out/CreateShopPort.java
+++ b/src/main/java/com/luckytree/shop_service/application/port/out/CreateShopPort.java
@@ -1,0 +1,11 @@
+package com.luckytree.shop_service.application.port.out;
+
+import com.luckytree.shop_service.adapter.out.ShopDetailEntity;
+import com.luckytree.shop_service.adapter.out.ShopListEntity;
+import lombok.RequiredArgsConstructor;
+
+public interface CreateShopPort {
+
+    Long saveShopDetail(ShopDetailEntity shopDetailEntity);
+    void saveShopList(ShopListEntity shopListEntity);
+}

--- a/src/main/java/com/luckytree/shop_service/application/service/CreateShopService.java
+++ b/src/main/java/com/luckytree/shop_service/application/service/CreateShopService.java
@@ -1,0 +1,30 @@
+package com.luckytree.shop_service.application.service;
+
+import com.luckytree.shop_service.application.port.in.CreateShopUseCase;
+import com.luckytree.shop_service.application.port.in.RequestShopRegistration;
+import com.luckytree.shop_service.application.port.out.CreateShopPort;
+import com.luckytree.shop_service.domain.ShopDetail;
+import com.luckytree.shop_service.domain.ShopList;
+import com.luckytree.shop_service.domain.ShopStatus;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateShopService implements CreateShopUseCase {
+
+    private final CreateShopPort createShopPort;
+
+    @Transactional
+    @Override
+    public void requestShopRegistration(RequestShopRegistration requestShopRegistration) {
+        ShopDetail shopDetail = new ShopDetail(requestShopRegistration);
+        Long shopDetailId = createShopPort.saveShopDetail(shopDetail.toEntity());
+
+        ShopList shopList = new ShopList(requestShopRegistration, shopDetailId, ShopStatus.DISABLE);
+        createShopPort.saveShopList(shopList.toEntity());
+    }
+
+}
+

--- a/src/main/java/com/luckytree/shop_service/domain/Hashtag.java
+++ b/src/main/java/com/luckytree/shop_service/domain/Hashtag.java
@@ -1,0 +1,5 @@
+package com.luckytree.shop_service.domain;
+
+public enum Hashtag {
+    GOOD, CLEAN, NICE, CHEAP, QUALITY
+}

--- a/src/main/java/com/luckytree/shop_service/domain/ShopDetail.java
+++ b/src/main/java/com/luckytree/shop_service/domain/ShopDetail.java
@@ -1,43 +1,66 @@
 package com.luckytree.shop_service.domain;
 
+import com.luckytree.shop_service.adapter.out.ShopDetailEntity;
+import com.luckytree.shop_service.application.port.in.RequestShopRegistration;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Table(name = "shop_detail")
-@Entity
-public class ShopDetail extends BaseTimeEntity{
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+@Getter
+@NoArgsConstructor
+public class ShopDetail {
 
-    @Column(length = 50, nullable = false)
+    private Long id;
     private String name;
-
-    @Column(length = 50)
     private String category;
-
-    @Column(length = 50, nullable = false)
     private String address;
-
-    @Column(length = 150)
     private String photo;
-
-    @Column(length = 50)
     private String contact;
-
-    @Column(length = 50)
     private String homepage;
-
-    @Column(length = 50)
     private String flagshipProduct;
-
-    @Column(length = 50)
-    private String hashtag;
-
-    @Column(length = 50, nullable = false)
+    private Hashtag hashtag;
     private String operatingTime;
-
-    @Column(length = 50)
     private String sns;
 
+    public ShopDetail(long id, String name, String category, String address, String photo, String contact, String homepage, String flagshipProduct, Hashtag hashtag, String operatingTime, String sns) {
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.address = address;
+        this.photo = photo;
+        this.contact = contact;
+        this.homepage = homepage;
+        this.flagshipProduct = flagshipProduct;
+        this.hashtag = hashtag;
+        this.operatingTime = operatingTime;
+        this.sns = sns;
+    }
+
+    public ShopDetail(RequestShopRegistration requestShopRegistration) {
+        this.name = requestShopRegistration.getShopName();
+        this.category = requestShopRegistration.getCategory();
+        this.address = requestShopRegistration.getAddress();
+        this.photo = requestShopRegistration.getPhoto();
+        this.contact = requestShopRegistration.getContact();
+        this.homepage = requestShopRegistration.getHomepage();
+        this.flagshipProduct = requestShopRegistration.getFlagshipProduct();
+        this.operatingTime = requestShopRegistration.getOperatingTime();
+        this.sns = requestShopRegistration.getSns();
+    }
+
+    public ShopDetailEntity toEntity() {
+        return ShopDetailEntity.builder()
+                .address(this.address)
+                .category(this.category)
+                .contact(this.contact)
+                .flagshipProduct(this.flagshipProduct)
+                .hashtag(this.hashtag)
+                .homepage(this.homepage)
+                .name(this.name)
+                .operatingTime(this.operatingTime)
+                .sns(this.sns)
+                .photo(this.photo)
+                .build();
+    }
 }

--- a/src/main/java/com/luckytree/shop_service/domain/ShopDetailAlteration.java
+++ b/src/main/java/com/luckytree/shop_service/domain/ShopDetailAlteration.java
@@ -1,4 +1,0 @@
-package com.luckytree.shop_service.domain;
-
-public class ShopDetailAlteration {
-}

--- a/src/main/java/com/luckytree/shop_service/domain/ShopList.java
+++ b/src/main/java/com/luckytree/shop_service/domain/ShopList.java
@@ -1,32 +1,51 @@
 package com.luckytree.shop_service.domain;
 
-import jakarta.persistence.*;
+import com.luckytree.shop_service.adapter.out.BaseTimeEntity;
+import com.luckytree.shop_service.adapter.out.ShopListEntity;
+import com.luckytree.shop_service.application.port.in.RequestShopRegistration;
+import lombok.Getter;
 
-@Table(name = "shop_list")
-@Entity
+@Getter
 public class ShopList extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
-
-    @Column(length = 20, nullable = false)
-    private String shopDetailId;
-
-    @Column(length = 50, nullable = false)
+    private Long id;
+    private Long shopDetailId;
     private String name;
-
-    @Column(length = 10, nullable = false)
-    private String status;
-
-    private double mapX;
-
-    private double mapY;
-
-    @Column(length = 50)
+    private ShopStatus status;
+    private Double mapX;
+    private Double mapY;
     private String category;
+    private Hashtag hashtag;
 
-    @Column(length = 50)
-    private String hashtag;
+    public ShopList(Long id, Long shopDetailId, String name, ShopStatus status, Double mapX, Double mapY, String category, Hashtag hashtag) {
+        this.id = id;
+        this.shopDetailId = shopDetailId;
+        this.name = name;
+        this.status = status;
+        this.mapX = mapX;
+        this.mapY = mapY;
+        this.category = category;
+        this.hashtag = hashtag;
+    }
 
+    public ShopList(RequestShopRegistration requestShopRegistration, Long shopDetailId, ShopStatus status) {
+        this.shopDetailId = shopDetailId;
+        this.name = requestShopRegistration.getShopName();
+        this.status = status;
+        this.mapX = requestShopRegistration.getMapX();
+        this.mapY = requestShopRegistration.getMapY();
+        this.category = requestShopRegistration.getCategory();
+    }
+
+    public ShopListEntity toEntity() {
+        return ShopListEntity.builder()
+                .hashtag(this.hashtag)
+                .shopDetailId(this.shopDetailId)
+                .category(this.category)
+                .mapX(this.mapX)
+                .mapY(this.mapY)
+                .name(this.name)
+                .status(this.status)
+                .build();
+    }
 }

--- a/src/main/java/com/luckytree/shop_service/domain/ShopStatus.java
+++ b/src/main/java/com/luckytree/shop_service/domain/ShopStatus.java
@@ -1,0 +1,5 @@
+package com.luckytree.shop_service.domain;
+
+public enum ShopStatus {
+    ENABLE, DISABLE, REMOVE_QUEST, UPDATE_QUEST
+}


### PR DESCRIPTION
## 작업내용

샵 디테일 도메인 모델 생성
샵 디테일 엔티티 생성
샵 리스트 도메인 모델 생성
샵 리스트 엔티티 생성
JPA Repository 각각 엔티티에 생성
어댑터와 포트로 컨트롤러와 비즈니스 로직 설계
도메인 모델에서 비즈니스 로직 가질 수 있도록 설계