### PR TITLE
feature/#7 [샵 삭제 요청 api 구현.]

### DIFF
--- a/src/main/java/com/luckytree/shop_service/shop/adapter/in/web/RemoveShopController.java
+++ b/src/main/java/com/luckytree/shop_service/shop/adapter/in/web/RemoveShopController.java
@@ -1,0 +1,27 @@
+package com.luckytree.shop_service.shop.adapter.in.web;
+
+import com.luckytree.shop_service.common.dto.ResultResponse;
+import com.luckytree.shop_service.shop.application.port.in.RemoveRequestForm;
+import com.luckytree.shop_service.shop.application.port.in.RemoveShopUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "샵 삭제", description = "샵 삭제 관련 API 모음")
+@RestController
+@RequestMapping("/shop/remove")
+@RequiredArgsConstructor
+public class RemoveShopController {
+
+    private final RemoveShopUseCase removeShopUseCase;
+
+    @Operation(summary = "샵 삭제요청 API")
+    @PostMapping("/request")
+    public ResultResponse removeShopRequest(@RequestBody @Valid RemoveRequestForm removeRequestForm) {
+        removeShopUseCase.removeShopRequest(removeRequestForm);
+        return new ResultResponse<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/RemoveShopPersistenceAdapter.java
+++ b/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/RemoveShopPersistenceAdapter.java
@@ -1,8 +1,10 @@
 package com.luckytree.shop_service.shop.adapter.out.persistence;
 
 import com.luckytree.shop_service.shop.application.port.out.RemoveShopPort;
+import com.luckytree.shop_service.shop.domain.ShopDetail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.webjars.NotFoundException;
 
 @RequiredArgsConstructor
 @Repository
@@ -10,8 +12,15 @@ public class RemoveShopPersistenceAdapter implements RemoveShopPort {
 
     private final ShopRemoveRepository shopRemoveRepository;
 
+    private final ShopRepository shopRepository;
+
     @Override
-    public void saveRemoveRequest(Long shopId, String comment) {
-        shopRemoveRepository.save(new ShopRemoveEntity(shopId, comment));
+    public void saveRemoveRequest(ShopEntity shopEntity, String comment) {
+        shopRemoveRepository.save(new ShopRemoveEntity(shopEntity, comment));
+    }
+
+    @Override
+    public ShopEntity getShopEntity(String name, String address) {
+       return shopRepository.findByNameAndAddress(name, address).orElseThrow(() -> new NotFoundException("해당 shopName과 address애 일치하는 ShopEntity가 없습니다. name: " + name + ", address: " + address));
     }
 }

--- a/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/RemoveShopPersistenceAdapter.java
+++ b/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/RemoveShopPersistenceAdapter.java
@@ -1,0 +1,17 @@
+package com.luckytree.shop_service.shop.adapter.out.persistence;
+
+import com.luckytree.shop_service.shop.application.port.out.RemoveShopPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class RemoveShopPersistenceAdapter implements RemoveShopPort {
+
+    private final ShopRemoveRepository shopRemoveRepository;
+
+    @Override
+    public void saveRemoveRequest(Long shopId, String commmet) {
+        shopRemoveRepository.save(new ShopRemoveEntity(shopId, commmet));
+    }
+}

--- a/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/RemoveShopPersistenceAdapter.java
+++ b/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/RemoveShopPersistenceAdapter.java
@@ -11,7 +11,7 @@ public class RemoveShopPersistenceAdapter implements RemoveShopPort {
     private final ShopRemoveRepository shopRemoveRepository;
 
     @Override
-    public void saveRemoveRequest(Long shopId, String commmet) {
-        shopRemoveRepository.save(new ShopRemoveEntity(shopId, commmet));
+    public void saveRemoveRequest(Long shopId, String comment) {
+        shopRemoveRepository.save(new ShopRemoveEntity(shopId, comment));
     }
 }

--- a/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopEntity.java
+++ b/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopEntity.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
 
 @Table(name = "shop")
 @Getter
@@ -74,7 +75,7 @@ public class ShopEntity extends BaseTimeEntity {
     private List<ShopTempEntity> shopTempEntityList;
 
     @OneToMany(mappedBy = "shopEntity")
-    private List<ShopRemoveEntity> shopRemoveEntityList;
+    private Set<ShopRemoveEntity> shopRemoveEntityList;
 
 
     public ShopEntity(ShopRequest shopRequest) {

--- a/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopEntity.java
+++ b/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopEntity.java
@@ -71,6 +71,10 @@ public class ShopEntity extends BaseTimeEntity {
     @OneToMany(mappedBy = "shopEntity")
     private List<ShopTempEntity> shopTempEntityList;
 
+    @OneToMany(mappedBy = "shopEntity")
+    private List<ShopRemoveEntity> shopRemoveEntityList;
+
+
     public ShopEntity(ShopRequest shopRequest) {
         this.name = shopRequest.getShopName();
         this.category = shopRequest.getCategory();

--- a/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopEntity.java
+++ b/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopEntity.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Set;
 
 @Table(name = "shop")
 @Getter
@@ -75,7 +74,7 @@ public class ShopEntity extends BaseTimeEntity {
     private List<ShopTempEntity> shopTempEntityList;
 
     @OneToMany(mappedBy = "shopEntity")
-    private Set<ShopRemoveEntity> shopRemoveEntityList;
+    private List<ShopRemoveEntity> shopRemoveEntityList;
 
 
     public ShopEntity(ShopRequest shopRequest) {

--- a/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopRemoveEntity.java
+++ b/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopRemoveEntity.java
@@ -1,0 +1,31 @@
+package com.luckytree.shop_service.shop.adapter.out.persistence;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "shop_remove")
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ShopRemoveEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id")
+    private ShopEntity shopEntity;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String comment;
+
+    public ShopRemoveEntity(ShopEntity shopEntity, String comment) {
+        this.shopEntity = shopEntity;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopRemoveRepository.java
+++ b/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopRemoveRepository.java
@@ -2,5 +2,5 @@ package com.luckytree.shop_service.shop.adapter.out.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ShopRemoveRepository extends JpaRepository<ShopRemoveRepository, Long> {
+public interface ShopRemoveRepository extends JpaRepository<ShopRemoveEntity, Long> {
 }

--- a/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopRemoveRepository.java
+++ b/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopRemoveRepository.java
@@ -1,0 +1,6 @@
+package com.luckytree.shop_service.shop.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopRemoveRepository extends JpaRepository<ShopRemoveRepository, Long> {
+}

--- a/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopTempEntity.java
+++ b/src/main/java/com/luckytree/shop_service/shop/adapter/out/persistence/ShopTempEntity.java
@@ -21,9 +21,6 @@ public class ShopTempEntity extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name="shop_id", nullable = false)
-    private Long shopId;
-
     @Column(length = 50, nullable = false)
     private String name;
 
@@ -72,7 +69,6 @@ public class ShopTempEntity extends BaseTimeEntity {
     private ShopEntity shopEntity;
 
     public ShopTempEntity(ShopRequest shopRequest, Long shopId) {
-        this.shopId = shopId;
         this.name = shopRequest.getShopName();
         this.category = shopRequest.getCategory();
         this.address = shopRequest.getAddress();

--- a/src/main/java/com/luckytree/shop_service/shop/application/port/in/RemoveRequestForm.java
+++ b/src/main/java/com/luckytree/shop_service/shop/application/port/in/RemoveRequestForm.java
@@ -1,0 +1,24 @@
+package com.luckytree.shop_service.shop.application.port.in;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RemoveRequestForm {
+
+    @NotBlank
+    @Size(max = 50)
+    private  String name;
+
+    @NotBlank
+    @Size(max = 50)
+    private String address;
+
+    @NotBlank
+    private String comment;
+}

--- a/src/main/java/com/luckytree/shop_service/shop/application/port/in/RemoveShopUseCase.java
+++ b/src/main/java/com/luckytree/shop_service/shop/application/port/in/RemoveShopUseCase.java
@@ -1,0 +1,6 @@
+package com.luckytree.shop_service.shop.application.port.in;
+
+public interface RemoveShopUseCase {
+
+    void removeShopRequest(RemoveRequestForm removeRequestForm);
+}

--- a/src/main/java/com/luckytree/shop_service/shop/application/port/out/RemoveShopPort.java
+++ b/src/main/java/com/luckytree/shop_service/shop/application/port/out/RemoveShopPort.java
@@ -1,0 +1,8 @@
+package com.luckytree.shop_service.shop.application.port.out;
+
+public interface RemoveShopPort {
+
+    void saveRemoveRequest(Long shopId, String commmet);
+
+
+}

--- a/src/main/java/com/luckytree/shop_service/shop/application/port/out/RemoveShopPort.java
+++ b/src/main/java/com/luckytree/shop_service/shop/application/port/out/RemoveShopPort.java
@@ -1,8 +1,11 @@
 package com.luckytree.shop_service.shop.application.port.out;
 
+import com.luckytree.shop_service.shop.adapter.out.persistence.ShopEntity;
+import com.luckytree.shop_service.shop.domain.ShopDetail;
+
 public interface RemoveShopPort {
 
-    void saveRemoveRequest(Long shopId, String commmet);
+    void saveRemoveRequest(ShopEntity shopEntity, String comment);
 
-
+    ShopEntity getShopEntity(String name, String address);
 }

--- a/src/main/java/com/luckytree/shop_service/shop/application/service/RemoveShopService.java
+++ b/src/main/java/com/luckytree/shop_service/shop/application/service/RemoveShopService.java
@@ -3,10 +3,12 @@ package com.luckytree.shop_service.shop.application.service;
 import com.luckytree.shop_service.shop.adapter.out.persistence.ShopEntity;
 import com.luckytree.shop_service.shop.application.port.in.RemoveRequestForm;
 import com.luckytree.shop_service.shop.application.port.in.RemoveShopUseCase;
+import com.luckytree.shop_service.shop.application.port.out.GetShopPort;
 import com.luckytree.shop_service.shop.application.port.out.RemoveShopPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.webjars.NotFoundException;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +19,7 @@ public class RemoveShopService implements RemoveShopUseCase {
     @Transactional
     @Override
     public void removeShopRequest(RemoveRequestForm removeRequestForm) {
-        ShopEntity shopEntity = removeShopPort.findByNameAndAddress(removeRequestForm.getName(), removeRequestForm.getAddress());
-        removeShopPort.saveRemoveRequest(shopEntity.getId(), removeRequestForm.getComment());
+        ShopEntity shopEntity = removeShopPort.getShopEntity(removeRequestForm.getName(), removeRequestForm.getAddress());
+        removeShopPort.saveRemoveRequest(shopEntity, removeRequestForm.getComment());
     }
 }

--- a/src/main/java/com/luckytree/shop_service/shop/application/service/RemoveShopService.java
+++ b/src/main/java/com/luckytree/shop_service/shop/application/service/RemoveShopService.java
@@ -1,0 +1,23 @@
+package com.luckytree.shop_service.shop.application.service;
+
+import com.luckytree.shop_service.shop.adapter.out.persistence.ShopEntity;
+import com.luckytree.shop_service.shop.application.port.in.RemoveRequestForm;
+import com.luckytree.shop_service.shop.application.port.in.RemoveShopUseCase;
+import com.luckytree.shop_service.shop.application.port.out.RemoveShopPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RemoveShopService implements RemoveShopUseCase {
+
+    private final RemoveShopPort removeShopPort;
+
+    @Transactional
+    @Override
+    public void removeShopRequest(RemoveRequestForm removeRequestForm) {
+        ShopEntity shopEntity = removeShopPort.findByNameAndAddress(removeRequestForm.getName(), removeRequestForm.getAddress());
+        removeShopPort.saveRemoveRequest(shopEntity.getId(), removeRequestForm.getComment());
+    }
+}


### PR DESCRIPTION
샵 리무브 엔티티 생성
샵 리무브 폼 생성
JPA Repository 각각 엔티티에 생성
어댑터와 포트로 컨트롤러와 비즈니스 로직 설계
도메인 모델에서 비즈니스 로직 가질 수 있도록 설계